### PR TITLE
concurrency with asyncio

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@ account.
 
 ## Usage
 
-1. Download and unzip the gist
+1. Clone this repo
 1. Setup python virtualenv
 1. Populate the environment
 1. Run the script
 
-### Download gist
+### Clone this repo
 
-Download and unzip this gist on dashboardweb1p.
+Clone this repo to wordpress1p.
 
 ### Setup python virtualenv
 
-Run these on on dashboardweb1p.
+Run these on on wordpress1p.
 
 You may need to install python3-venv with apt-get.
 
@@ -26,24 +26,24 @@ You may need to install python3-venv with apt-get.
 
 ### Populate the environment
 
-env.sample contains the structure
+env.sample contains the environment template.
 
-    $ env_file=$(mktemp)
-    $ vi $env_file
+    $ cp env.sample .env
+    $ vi .env
 
-SRC credentials are the FCS environment. Bucket name is found in /var/www/dashboard/current/.env.
+SRC credentials are the FCS environment. Bucket name is found in /var/www/datagov/current/.env.
 
 DEST variables come from the cloud.gov service-key, these are run on your local
 development environment.
 
     $ cf target -s $space
-    $ cf service-key dashboard-s3 fcs-migration
+    $ cf service-key fcs-lifeboat fcs-migration
 
 ### Run the script
 
-Run these steps on dashboardweb1p in a tmux environment.
+Run these steps on wordpress1p in a tmux environment.
 
-    $ source $env_file
+    $ source .env
     $ source venv/bin/activate
     $ time python migrate.py --use-ec2
 

--- a/migrate.py
+++ b/migrate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import asyncio
 import logging

--- a/migrate.py
+++ b/migrate.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import os
 import sys
@@ -50,13 +51,13 @@ def list_objects(s3, bucket, prefix):
             break
 
 
-
-def main():
+async def main():
     parser = argparse.ArgumentParser(description='S3 migration utility.')
     parser.add_argument('--use-ec2', action='store_true', help='Read source credentials from EC2 metadata.')
     parser.add_argument('--src-service-name', action='store', help='Name of the cloud.gov s3 service to copy from.')
     parser.add_argument('--dest-service-name', action='store', help='Name of the cloud.gov s3 service to copy to.')
     parser.add_argument('--clear', action='store_true', help='Clear the destination bucket before copying objects.')
+    parser.add_argument('--concurrency', type=int, default=4, help='Number of copy workers to run concurrently.')
     parser.add_argument('--debug', action='store_true', help='Use debug logging.')
     parser.add_argument('--prefix', action='store', default='', help='Source S3 prefix to use.')
     args = parser.parse_args()
@@ -113,18 +114,53 @@ def main():
         log.info(f'clearing destination bucket={dest_bucket}')
         clear_bucket(dest_s3, dest_bucket)
 
+    async def worker(worker_num, queue):
+        while True:
+            # get a "work item" out of the queue.
+            obj = await queue.get()
+
+            key = obj.get('Key')
+            if key_exists(dest_s3, dest_bucket, key):
+                log.debug(f'worker={worker_num} skipping key={key} already exists on destination')
+                continue
+
+            log.info(f'worker={worker_num} copying key={key}')
+            with tempfile.NamedTemporaryFile() as temp:
+                # TODO use a pipe with asyncio to prevent serial download + upload
+                src_s3.download_fileobj(src_bucket, key, temp)
+                temp.seek(0)
+                dest_s3.upload_fileobj(temp, dest_bucket, key)
+
+            # Notify the queue that the "work item" has been processed.
+            queue.task_done()
+
+    # setup workers
+    tasks = []
+    queue = asyncio.Queue(maxsize=100)  # We put a maxsize to prevent queing 90k objects in memory
+    log.debug(f'starting concurrency={args.concurrency} copy tasks...')
+    for i in range(args.concurrency):
+        task = asyncio.create_task(worker(i, queue))
+        tasks.append(task)
+
     # iterate over each object
     for obj in list_objects(src_s3, src_bucket, src_prefix):
-        key = obj.get('Key')
-        if key_exists(dest_s3, dest_bucket, key):
-            log.debug(f'skipping key={key} already exists on destination')
-            continue
+        await queue.put(obj)  # This will wait if the queue is full, preventing large queuing in memory
 
-        log.info(f'copying key={key}')
-        with tempfile.NamedTemporaryFile() as temp:
-            src_s3.download_fileobj(src_bucket, key, temp)
-            temp.seek(0)
-            dest_s3.upload_fileobj(temp, dest_bucket, key)
+    # wait for queue to drain
+    await queue.join()
+
+    log.info('done processing queue')
+
+    # Cancel our worker tasks who are waiting on an empty queue
+    for task in tasks:
+        task.cancel()
+
+    log.info('cancelling tasks...')
+    # Wait until all worker tasks are cancelled.
+    await asyncio.gather(*tasks, return_exceptions=True)
+    log.info('done')
+
+
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/3588

This doesn't work and I don't really suggest picking it up. Leaving it here in
case it's useful.

Although it adds asyncio and concurrency, the boto APIs are still synchronous,
so a single worker ends up picking up all the tasks so it's no faster than
before.

This [article](https://medium.com/tysonworks/concurrency-with-boto3-41cfa300aab4) suggests using the ThreadPoolExecutor as the asyncio loop executor. boto **is** threadsafe, so that sounds good to me. However, I don't think the rest of the code I wrote is threadsafe, so I'm not sure we can just drop that in.

- add async and concurrency
- allow for running script directly
