### PR TITLE
Try xargs for parallel upload/speedup

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,1 @@
+export PATH="$(pwd)/bin:$PATH"

--- a/bin/aws_cp.sh
+++ b/bin/aws_cp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+object=$1
+
+
+# Test if object exists
+if aws --region "$DEST_REGION" s3 ls "s3://$DEST_BUCKET_NAME/$object" > /dev/null; then
+  echo "skipping, already exists key=$object"
+else
+  echo "copying key=$object"
+  # Object doesn't exist, copy it
+  aws s3 cp --region "$DEST_REGION" --source-region "$SRC_REGION" "s3://$SRC_BUCKET_NAME/$object" "s3://$DEST_BUCKET_NAME/$object"
+fi

--- a/bin/xargs_copy.sh
+++ b/bin/xargs_copy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# This assumes the source bucket is public and avoids us calling ListObjectsV2 on the source bucket.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+concurrency=4
+
+optstring=":c:s:d:p:"
+while getopts ${optstring} option; do
+  case "${option}" in
+    c)
+      concurrency="${OPTARG:-}"
+      ;;
+    d)
+      dest_service="${OPTARG:-}"
+      ;;
+    p)
+      src_prefix="${OPTARG:-}"
+      ;;
+    s)
+      src_service="${OPTARG:-}"
+      ;;
+    :)
+      echo "Option -${OPTARG:-} requires an argument"
+      echo
+      usage
+      exit 1
+      ;;
+    ?)
+      echo "Invalid option: -${OPTARG:-}"
+      echo
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+function fail () {
+  echo error: "$@" >&2
+  exit 2
+}
+
+# TODO what to do with prefix?
+if [[ -n "${src_prefix:-}" ]]; then
+  SRC_PREFIX="$src_prefix"
+fi
+
+if [[ -n "${src_service:-}" ]]; then
+  SRC_BUCKET_NAME="$(jq -r -e ".[\"s3\"][] | select(name==$src_service).credentials.bucket")"
+  SRC_REGION="$(jq -r -e ".[\"s3\"][] | select(name==$src_service).credentials.region")"
+fi
+
+if [[ -n "${dest_service:-}" ]]; then
+  DEST_BUCKET_NAME="$(jq -r -e ".[\"s3\"][] | select(name==$dest_service).credentials.bucket")"
+  DEST_ACCESS_KEY_ID="$(jq -r -e ".[\"s3\"][] | select(name==$dest_service).credentials.access_key_id")"
+  DEST_SECRET_ACCESS_KEY="$(jq -r -e ".[\"s3\"][] | select(name==$dest_service).credentials.secret_access_key")"
+  DEST_REGION="$(jq -r -e ".[\"s3\"][] | select(name==$dest_service).credentials.region")"
+fi
+
+[[ -z "$SRC_BUCKET_NAME" ]] && fail SRC_BUCKET_NAME not set
+[[ -z "$SRC_REGION" ]] && fail SRC_REGION not set
+[[ -z "$DEST_BUCKET_NAME" ]] && fail DEST_BUCKET_NAME not set
+[[ -z "$DEST_ACCESS_KEY_ID" ]] && fail DEST_ACCESS_KEY_ID not set
+[[ -z "$DEST_SECRET_ACCESS_KEY" ]] && fail DEST_SECRET_ACCESS_KEY not set
+[[ -z "$DEST_REGION" ]] && fail DEST_REGION not set
+
+
+
+# Input comes from `aws s3 ls --recursive s3://bucket/`
+# This assumes your source bucket is public.
+# input looks like this
+# 2021-12-10 12:16:25      18066 datagov/wordpress/ansible.cfg
+awk '{print $4}' |
+  AWS_ACCESS_KEY_ID="$DEST_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$DEST_SECRET_ACCESS_KEY" \
+  xargs -n 1 -P "$concurrency" bin/aws_cp.sh


### PR DESCRIPTION
This is not fully tested and I don't recommend following up with this, leaving
it here in case it's useful.

https://github.com/GSA/datagov-deploy/issues/3588

Experiment to use aws cli with xargs to copy across buckets in parallel.
Unfortunately, the `ls` is too slow, and it still seems to take a while for the
parallelism to be useful :shrug:

This assumes the source bucket is public (hence you can get away with only
destination credentials, like in cloud.gov).

I have not tested the vcap services parsing at all.
